### PR TITLE
Delete targets bug fix

### DIFF
--- a/angular-targets-frontend/src/app/pages/create-target/create-target.component.ts
+++ b/angular-targets-frontend/src/app/pages/create-target/create-target.component.ts
@@ -46,15 +46,15 @@ export class CreateTargetComponent implements OnInit {
   save() {
     const formData = this.form.value;
 
-    this.apiService.createTarget(formData).subscribe(() => {
-      this.router.navigateByUrl('/view/targets');
-    });
+    this.apiService.createTarget(formData);
+    this.targets$ = this.apiService.targets;
+    this.resetForm();
   }
 
   resetForm() {
     this.form = this.fb.group({
       targetName: [''],
-      keyContacts: this.fb.array(['']),
+      keyContacts: this.fb.array([this.addKeyContactsFormGroup()]),
       companyInformation: [''],
       kpiData: this.fb.group({ startYearValue: [''], endYearValue: [''] }),
       status: ['RESEARCHING']

--- a/angular-targets-frontend/src/app/pages/edit-target/edit-target.component.ts
+++ b/angular-targets-frontend/src/app/pages/edit-target/edit-target.component.ts
@@ -23,7 +23,7 @@ export class EditTargetComponent implements OnInit {
     // some test form data to get the POST right.
     this.form = this.fb.group({
       targetName: [''],
-      keyContacts: this.fb.array([this.addKeyContactsFormGroup()]),
+      keyContacts: this.fb.array([]),
       companyInformation: [''],
       kpiData: this.fb.group({ startYearValue: [''], endYearValue: [''] }),
       status: ['RESEARCHING']
@@ -50,10 +50,29 @@ export class EditTargetComponent implements OnInit {
           kpiData,
           status
         });
+        // loop over single target records keyContacts and create a formgroup object for each one.
+        target.keyContacts.forEach(contact => {
+          (this.form.get('keyContacts') as FormArray).push(
+            this.createContactsFormGroup(
+              contact.name,
+              contact.phone,
+              contact.title
+            )
+          );
+        });
       });
     });
   }
+  // created a method to dynamically push a formGrp for each contact coming from backend
+  createContactsFormGroup(name: any, phone: any, title: any): FormGroup {
+    return this.fb.group({
+      name: [name],
+      phone: [phone],
+      title: [title]
+    });
+  }
 
+  // all an empty formgroup so that user can add a contact to the target record
   addKeyContactsFormGroup(): FormGroup {
     return this.fb.group({
       name: [''],
@@ -64,11 +83,9 @@ export class EditTargetComponent implements OnInit {
 
   save() {
     const formData = this.form.value;
-    console.log(formData);
-
-    this.apiService.updateTarget(this.id, formData).subscribe(() => {
-      this.router.navigateByUrl('/view/targets');
-    });
+    this.apiService.updateTarget(this.id, formData);
+    this.targets$ = this.apiService.targets;
+    this.router.navigateByUrl('/view/targets');
   }
 
   addKeyContactClick(): void {

--- a/angular-targets-frontend/src/app/pages/view-targets/view-targets.component.html
+++ b/angular-targets-frontend/src/app/pages/view-targets/view-targets.component.html
@@ -8,8 +8,11 @@
     heading="{{ target.targetName }}"
   >
     <ul class="list-group">
-      <button class="class btn btn-primary" (click)="goToEdit(target._id)">
+      <button class="class btn btn-primary" (click)="goToEdit(target.id)">
         Edit Target
+      </button>
+      <button class="class btn btn-danger" (click)="delete(target.id)">
+        Delete Target
       </button>
       <li class="list-group-item">Status: {{ target.status }}</li>
       <li class="list-group-item">Annual Growth Rate: {{ target.agr }}</li>

--- a/angular-targets-frontend/src/app/pages/view-targets/view-targets.component.ts
+++ b/angular-targets-frontend/src/app/pages/view-targets/view-targets.component.ts
@@ -18,8 +18,11 @@ export class ViewTargetsComponent implements OnInit {
     this.targets$ = this.apiService.targets;
   }
 
-  goToEdit(id) {
-    console.log(id);
+  goToEdit(id: any) {
     this.router.navigate(['/edit/target', id]);
+  }
+
+  delete(id: any) {
+    this.apiService.deleteTarget(id);
   }
 }

--- a/handlers/targets.js
+++ b/handlers/targets.js
@@ -38,7 +38,7 @@ exports.updateTargetById = (req, res, next) => {
 exports.deleteTargetById = (req, res, next) => {
   const id = req.params.id;
 
-  Targets.findOneAndDelete(id)
+  Targets.findByIdAndDelete(id)
     .then(result => res.status(200).json(result))
     .catch(error => next({ status: 400, message: error.message }));
 };


### PR DESCRIPTION
fixed a nasty issue I was having with deleting targets.  I mistakenly used findOneAndDelete instead of findByIdAndDelete which is the one I meant to use.  The problem I was having was that when you deleted a record it would delete the one before it every time.  Very strange behaviour from a method. You would think it would just fail and return an error but it doesn't.  Live and Learn I guess. :P 